### PR TITLE
Add sad path test to raise coverage to 100%

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,8 +39,8 @@ class ItemsController < ApplicationController
         flash[:notice] = 'Item updated successfully!'
         redirect_to merchant_item_path(@item.merchant, @item)
       else
-        flash.now[:alert] = @item.errors.full_messages
-        render :edit
+        flash[:alert] = "Error: #{@item.errors.full_messages}"
+        redirect_to edit_merchant_item_path(@item.merchant, @item)
       end
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,4 +4,8 @@ class Item < ApplicationRecord
   belongs_to :merchant
 
   enum status: [ :disabled, :enabled ]
+
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :description, presence: true
+  validates :unit_price, presence: true, numericality: true
 end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,8 +5,8 @@
   <%= form.text_field :name %>
   <%= form.label :description %>
   <%= form.text_area :description %>
-  <%= form.label :price %>
-  <%= form.number_field :price %>
+  <%= form.label :unit_price, 'Price' %>
+  <%= form.number_field :unit_price %>
   <%= form.hidden_field :status, value: :disabled %>
   <%= form.submit "Submit" %>
 <% end %>

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Merchant Items Edit Page", type: :feature do
       expect(page).to have_current_path(merchant_item_path(@merchant, @item))
       expect(page).to have_content('Item updated successfully!')
     end
-    it 'rerenders the page with a flash message when the item is not successfully updated' do
+    it 'goes back to the edit page with a flash message when the item is not successfully updated' do
       visit edit_merchant_item_path(@merchant, @item)
 
       fill_in 'Name:', with: 'This is an very long string that exceeds fifty characters in length'
@@ -53,6 +53,11 @@ RSpec.feature "Merchant Items Edit Page", type: :feature do
 
       expect(page).to have_current_path(edit_merchant_item_path(@merchant, @item))
       expect(page).to have_content('Error:')
+
+      visit merchant_item_path(@merchant, @item)
+     
+      expect(page).not_to have_content('This is an very long string that exceeds fifty characters in length')
+      expect(page).to have_content('Wooden Necklace')
     end
   end
 end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -45,5 +45,14 @@ RSpec.feature "Merchant Items Edit Page", type: :feature do
       expect(page).to have_current_path(merchant_item_path(@merchant, @item))
       expect(page).to have_content('Item updated successfully!')
     end
+    it 'rerenders the page with a flash message when the item is not successfully updated' do
+      visit edit_merchant_item_path(@merchant, @item)
+
+      fill_in 'Name:', with: 'This is an very long string that exceeds fifty characters in length'
+      click_button 'Update'
+
+      expect(page).to have_current_path(edit_merchant_item_path(@merchant, @item))
+      expect(page).to have_content('Error:')
+    end
   end
 end

--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'new merchant item', type: :feature do
         expect(page).to have_selector(:css, "form")
         expect(page).to have_field(:name)
         expect(page).to have_field(:description)
-        expect(page).to have_field(:price)
+        expect(page).to have_field(:unit_price)
       end
 
       it '- when I fill out the form, I click (submit). then I am directed back to the items index page, where I see

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,4 +6,12 @@ RSpec.describe Item, type: :model do
     it { should have_many(:invoice_items) }
     it { should have_many(:invoices).through(:invoice_items) }
   end
+
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_most(50) }
+    it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:unit_price) }
+    it { should validate_numericality_of(:unit_price) }
+  end
 end


### PR DESCRIPTION
- Adds sad path test for the item edit form
- Adds validations for the item model regarding name, description, and unit price
- Fixes inconsistencies with param names that prevented valid items from being created
- Raises coverage to 100% as of this PR!