### PR TITLE
Display total revenue from the invoice on the admin invoice show page

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -2,5 +2,6 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
     @customer = @invoice.customer
+    @total_revenue = @invoice.admin_total_revenue
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -17,4 +17,10 @@ class Invoice < ApplicationRecord
     .where("items.merchant_id = ?", merchant_id)
     .sum("quantity * invoice_items.unit_price")
   end
+
+  def admin_total_revenue
+    invoice_items
+    .joins(:item)
+    .sum("quantity * invoice_items.unit_price")
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,3 +2,4 @@
 <p>Status: <%=@invoice.status%></p>
 <p>Created on <%=@invoice.created_at.strftime("%A, %B %e, %Y")%></p>
 <p>Customer: <%="#{@customer.first_name} #{@customer.last_name}"%></p>
+<p>Total Revenue: $<%= @total_revenue %></p>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Admin Invoice Show Page", type: :feature do
       @crystal_moon = Merchant.create!(name: "Crystal Moon Designs")
       @surf_designs = Merchant.create!(name: "Surf & Co. Designs")
       @merchant_3 = Merchant.create!(name: "Outer Outfitters")
-  
+
       @pearl = @crystal_moon.items.create!(name: "Pearl", description: "Not a BlackPearl!", unit_price: 25)
       @moon_rock = @crystal_moon.items.create!(name: "Moon Rock", description: "Evolve Your Pokemon!", unit_price: 105)
       @lapis_lazuli = @crystal_moon.items.create!(name: "Lapis Lazuli", description: "Not the Jewel Knight!", unit_price: 45)
@@ -22,14 +22,15 @@ RSpec.feature "Admin Invoice Show Page", type: :feature do
       @rash_guard = @surf_designs.items.create!(name: "Radical Rash Guard", description: "Stay totally groovy and rash free!", unit_price: 50)
       @zinc = @surf_designs.items.create!(name: "100% Zinc Face Protectant", description: "Our original organic formula!", unit_price: 13)
       @surf_board = @surf_designs.items.create!(name: "Surf Board", description: "Our original 12' board!", unit_price: 200)
-  
+      @snorkel = @surf_designs.items.create!(name: "Snorkel", description: "Perfect for reef viewing!", unit_price: 400)
+
       @paul = Customer.create!(first_name: "Paul", last_name: "Walker")
       @sam = Customer.create!(first_name: "Sam", last_name: "Gamgee")
       @abbas = Customer.create!(first_name: "Abbas", last_name: "Firnas")
       @hamada = Customer.create!(first_name: "Hamada", last_name: "Hilal")
       @frodo = Customer.create!(first_name: "Frodo", last_name: "Baggins")
       @eevee = Customer.create!(first_name: "Eevee", last_name: "Ketchup")
-  
+
       @invoice_1 = Invoice.create!(status: 2, customer_id: @paul.id)
       @invoice_2 = Invoice.create!(status: 2, customer_id: @paul.id)
       @invoice_3 = Invoice.create!(status: 2, customer_id: @sam.id)
@@ -52,7 +53,7 @@ RSpec.feature "Admin Invoice Show Page", type: :feature do
       @invoice_20 = Invoice.create!(status: 2, customer_id: @frodo.id)
       @invoice_21 = Invoice.create!(status: 2, customer_id: @paul.id)
       @invoice_22 = Invoice.create!(status: 2, customer_id: @eevee.id)
-  
+
       @pearl_invoice = InvoiceItem.create!(item_id: @pearl.id, invoice_id: @invoice_1.id, quantity: 2, unit_price: 25, status: 1)
       @moon_rock_invoice = InvoiceItem.create!(item_id: @moon_rock.id, invoice_id: @invoice_2.id, quantity: 2, unit_price: 105, status: 1)
       @lapis_lazuli_invoice = InvoiceItem.create!(item_id: @lapis_lazuli.id, invoice_id: @invoice_3.id, quantity: 2, unit_price: 45, status: 1)
@@ -68,7 +69,8 @@ RSpec.feature "Admin Invoice Show Page", type: :feature do
       @rash_guard_invoice = InvoiceItem.create!(item_id: @rash_guard.id, invoice_id: @invoice_13.id, quantity: 2, unit_price: 50, status: 2)
       @zinc_invoice = InvoiceItem.create!(item_id: @zinc.id, invoice_id: @invoice_14.id, quantity: 2, unit_price: 13, status: 1)
       @surf_board_invoice = InvoiceItem.create!(item_id: @surf_board.id, invoice_id: @invoice_6.id, quantity: 2, unit_price: 200, status: 1)
-  
+      @snorkel_invoice = InvoiceItem.create!(item_id: @snorkel.id, invoice_id: @invoice_6.id, quantity: 3, unit_price: 400, status: 1)
+
       @transaction_1 = Transaction.create!(result: 1, invoice_id: @invoice_1.id, credit_card_number: 0001)
       @transaction_2 = Transaction.create!(result: 1, invoice_id: @invoice_2.id, credit_card_number: 0002)
       @transaction_3 = Transaction.create!(result: 1, invoice_id: @invoice_3.id, credit_card_number: 0003)
@@ -93,13 +95,19 @@ RSpec.feature "Admin Invoice Show Page", type: :feature do
       @transaction_22 = Transaction.create!(result: 0, invoice_id: @invoice_17.id, credit_card_number: 0016)
     end
     it 'shows information related to the invoice' do
-      @invoice_1.created_at = Time.new(2022, 11, 8)
-
+      # @invoice_1.created_at = Time.new(2022, 11, 8)
+      @invoice_1.update!(created_at: Time.new(2022, 11, 8)) #using .update will save the update to created_at
       visit admin_invoice_path(@invoice_1)
       expect(page).to have_content("ID: #{@invoice_1.id}")
       expect(page).to have_content("Status: completed")
       expect(page).to have_content("Created on Tuesday, November 8, 2022")
       expect(page).to have_content("Customer: Paul Walker")
+    end
+    it 'shows the total revenue that will be generated from the invoice' do
+      visit admin_invoice_path(@invoice_6)
+      # save_and_open_page
+      # require "pry"; binding.pry
+      expect(page).to have_content("Total Revenue: $1770")
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Admin Merchant Index", type: :feature do
 
         click_button "Enable Crystal Moon Designs"
       end
-        
+
       expect(current_path).to eq(admin_merchants_path)
       expect(page).to have_content("This storefront is currently: OPEN")
     end
@@ -50,7 +50,7 @@ RSpec.describe "Admin Merchant Index", type: :feature do
         expect(page).to have_content("#{@merchant_2.name}")
         expect(page).to have_content("#{@merchant_3.name}")
       end
-      
+
       within "#merchant-disabled" do
         expect(page).to_not have_content("#{@merchant_1.name}")
         expect(page).to_not have_content("#{@merchant_2.name}")
@@ -64,7 +64,7 @@ RSpec.describe "Admin Merchant Index", type: :feature do
         expect(page).to have_content("#{@merchant_3.name}")
         expect(page).to_not have_content("#{@merchant_1.name}")
       end
-      
+
       within "#merchant-disabled" do
         expect(page).to have_content("#{@merchant_1.name}")
         expect(page).to_not have_content("#{@merchant_2.name}")
@@ -78,7 +78,7 @@ RSpec.describe "Admin Merchant Index", type: :feature do
         expect(page).to_not have_content("#{@merchant_1.name}")
         expect(page).to_not have_content("#{@merchant_3.name}")
       end
-    
+
       within "#merchant-disabled" do
         expect(page).to have_content("#{@merchant_1.name}")
         expect(page).to_not have_content("#{@merchant_2.name}")
@@ -92,7 +92,7 @@ RSpec.describe "Admin Merchant Index", type: :feature do
         expect(page).to have_content("#{@merchant_2.name}")
         expect(page).to_not have_content("#{@merchant_3.name}")
       end
-    
+
       within "#merchant-disabled" do
         expect(page).to have_content("#{@merchant_3.name}")
         expect(page).to_not have_content("#{@merchant_1.name}")

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Invoice, type: :model do
       @transaction_21 = Transaction.create!(result: 0, invoice_id: @invoice_21.id, credit_card_number: 0016)
       @transaction_22 = Transaction.create!(result: 0, invoice_id: @invoice_17.id, credit_card_number: 0016)
     end
-    describe '#invoice_item(item_id)' do 
+    describe '#invoice_item(item_id)' do
       it 'gives us access to each invoice item' do
         expect(@invoice_6.invoice_item(@emerald.id)).to eq(@emerald_invoice)
         expect(@invoice_6.invoice_item(@surf_board.id)).to eq(@surf_board_invoice)
@@ -110,6 +110,12 @@ RSpec.describe Invoice, type: :model do
     describe '#total_revenue(merchant_id)' do
       it 'gives us the total revenue of all items on this invoice that belong to the given merchant' do
         expect(@invoice_6.total_revenue(@surf_designs.id)).to eq(1600)
+      end
+    end
+
+    describe '#admin_total_revenue' do
+      it 'gives us the total revenue of all items on this invoice that belong to all merchants' do
+        expect(@invoice_6.admin_total_revenue).to eq(1770)
       end
     end
   end


### PR DESCRIPTION
This PR will:
- Complete Admin Invoice Show Page: Total Revenue user story
- Could come back and reformat the revenue number to have commas/decimal point to match wireframe
- Testing is showing 100% coverage